### PR TITLE
Update all drivers to the new Buffer API

### DIFF
--- a/drivers/bbdmx.js
+++ b/drivers/bbdmx.js
@@ -7,7 +7,6 @@ function BBDMX(deviceId = '127.0.0.1', options = {}) {
 
   self.options = options;
   self.universe = Buffer.alloc(UNIVERSE_LEN + 1);
-  self.universe.fill(0);
   self.host = deviceId;
   self.port = self.options.port || 9930;
   self.dev = dgram.createSocket('udp4');
@@ -17,10 +16,10 @@ function BBDMX(deviceId = '127.0.0.1', options = {}) {
 
 BBDMX.prototype.sendUniverse = function () {
   let channel;
-  let messageBuffer = Buffer.alloc(UNIVERSE_LEN.toString());
+  let messageBuffer = Buffer.from(UNIVERSE_LEN.toString());
 
   for (const i = 1; i <= UNIVERSE_LEN; i++) {
-    channel = Buffer.alloc(' ' + this.universe[i]);
+    channel = Buffer.from(' ' + this.universe[i]);
     messageBuffer = Buffer.concat([messageBuffer, channel]);
   }
   this.dev.send(messageBuffer, 0, messageBuffer.length, this.port, this.host);

--- a/drivers/bbdmx.js
+++ b/drivers/bbdmx.js
@@ -6,7 +6,7 @@ function BBDMX(deviceId = '127.0.0.1', options = {}) {
   const self = this;
 
   self.options = options;
-  self.universe = new Buffer(UNIVERSE_LEN + 1);
+  self.universe = Buffer.alloc(UNIVERSE_LEN + 1);
   self.universe.fill(0);
   self.host = deviceId;
   self.port = self.options.port || 9930;
@@ -17,10 +17,10 @@ function BBDMX(deviceId = '127.0.0.1', options = {}) {
 
 BBDMX.prototype.sendUniverse = function () {
   let channel;
-  let messageBuffer = new Buffer(UNIVERSE_LEN.toString());
+  let messageBuffer = Buffer.alloc(UNIVERSE_LEN.toString());
 
   for (const i = 1; i <= UNIVERSE_LEN; i++) {
-    channel = new Buffer(' ' + this.universe[i]);
+    channel = Buffer.alloc(' ' + this.universe[i]);
     messageBuffer = Buffer.concat([messageBuffer, channel]);
   }
   this.dev.send(messageBuffer, 0, messageBuffer.length, this.port, this.host);

--- a/drivers/dmx4all.js
+++ b/drivers/dmx4all.js
@@ -6,7 +6,6 @@ function DMX4ALL(deviceId, options = {}) {
   const self = this;
 
   this.universe = Buffer.alloc(UNIVERSE_LEN + 1);
-  this.universe.fill(0);
 
   this.dev = new SerialPort(deviceId, {
     'baudRate': 38400,

--- a/drivers/dmx4all.js
+++ b/drivers/dmx4all.js
@@ -5,7 +5,7 @@ const UNIVERSE_LEN = 512;
 function DMX4ALL(deviceId, options = {}) {
   const self = this;
 
-  this.universe = new Buffer(UNIVERSE_LEN + 1);
+  this.universe = Buffer.alloc(UNIVERSE_LEN + 1);
   this.universe.fill(0);
 
   this.dev = new SerialPort(deviceId, {
@@ -28,7 +28,7 @@ DMX4ALL.prototype.sendUniverse = function () {
     return;
   }
 
-  const msg = Buffer(UNIVERSE_LEN * 3);
+  const msg = Buffer.alloc(UNIVERSE_LEN * 3);
 
   for (let i = 0; i < UNIVERSE_LEN; i++) {
     msg[i * 3 + 0] = (i < 256) ? 0xE2 : 0xE3;

--- a/drivers/enttec-open-usb-dmx.js
+++ b/drivers/enttec-open-usb-dmx.js
@@ -6,7 +6,6 @@ function EnttecOpenUsbDMX(deviceId, options) {
   options = options || {};
 
   this.universe = Buffer.alloc(513);
-  this.universe.fill(0);
 
   self.interval = 46;
 

--- a/drivers/enttec-open-usb-dmx.js
+++ b/drivers/enttec-open-usb-dmx.js
@@ -5,7 +5,7 @@ function EnttecOpenUsbDMX(deviceId, options) {
 
   options = options || {};
 
-  this.universe = new Buffer(513);
+  this.universe = Buffer.alloc(513);
   this.universe.fill(0);
 
   self.interval = 46;


### PR DESCRIPTION
Updated the remaining Drivers to the new Buffer API. 

As the new requirement is now Node 10 I did not add a fallback to the old methods as the previous PRs did.

fixes #58 
fixes #59 
fixes #60 