### PR TITLE
Changed update event so it also catches animations

### DIFF
--- a/drivers/artnet.js
+++ b/drivers/artnet.js
@@ -1,4 +1,6 @@
 const dgram = require('dgram');
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
 
 function ArtnetDriver(deviceId = '127.0.0.1', options = {}) {
   const self = this;
@@ -56,6 +58,8 @@ ArtnetDriver.prototype.update = function (u) {
   for (const c in u) {
     this.universe[c] = u[c];
   }
+
+  this.emit('update', u);
 };
 
 ArtnetDriver.prototype.updateAll = function (v) {
@@ -67,5 +71,7 @@ ArtnetDriver.prototype.updateAll = function (v) {
 ArtnetDriver.prototype.get = function (c) {
   return this.universe[c];
 };
+
+util.inherits(ArtnetDriver, EventEmitter);
 
 module.exports = ArtnetDriver;

--- a/drivers/bbdmx.js
+++ b/drivers/bbdmx.js
@@ -1,4 +1,6 @@
 const dgram = require('dgram');
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
 
 const UNIVERSE_LEN = 512;
 
@@ -42,6 +44,8 @@ BBDMX.prototype.update = function (u) {
   for (const c in u) {
     this.universe[c] = u[c];
   }
+
+  this.emit('update', u);
 };
 
 BBDMX.prototype.updateAll = function (v) {
@@ -53,5 +57,7 @@ BBDMX.prototype.updateAll = function (v) {
 BBDMX.prototype.get = function (c) {
   return this.universe[c];
 };
+
+util.inherits(BBDMX, EventEmitter);
 
 module.exports = BBDMX;

--- a/drivers/dmx4all.js
+++ b/drivers/dmx4all.js
@@ -1,4 +1,6 @@
 const SerialPort = require('serialport');
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
 
 const UNIVERSE_LEN = 512;
 
@@ -49,6 +51,8 @@ DMX4ALL.prototype.update = function (u) {
     this.universe[c] = u[c];
   }
   this.sendUniverse();
+
+  this.emit('update', u);
 };
 
 DMX4ALL.prototype.updateAll = function (v) {
@@ -61,5 +65,7 @@ DMX4ALL.prototype.updateAll = function (v) {
 DMX4ALL.prototype.get = function (c) {
   return this.universe[c];
 };
+
+util.inherits(DMX4ALL, EventEmitter);
 
 module.exports = DMX4ALL;

--- a/drivers/dmxking-ultra-dmx-pro.js
+++ b/drivers/dmxking-ultra-dmx-pro.js
@@ -1,4 +1,6 @@
 const SerialPort = require('serialport');
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
 
 const DMXKING_ULTRA_DMX_PRO_DMX_STARTCODE = 0x00;
 const DMXKING_ULTRA_DMX_PRO_START_OF_MSG = 0x7e;
@@ -66,6 +68,8 @@ DMXKingUltraDMXPro.prototype.update = function (u) {
     this.universe[c] = u[c];
   }
   this.sendUniverse();
+
+  this.emit('update', u);
 };
 
 DMXKingUltraDMXPro.prototype.updateAll = function (v) {
@@ -78,5 +82,7 @@ DMXKingUltraDMXPro.prototype.updateAll = function (v) {
 DMXKingUltraDMXPro.prototype.get = function (c) {
   return this.universe[c];
 };
+
+util.inherits(DMXKingUltraDMXPro, EventEmitter);
 
 module.exports = DMXKingUltraDMXPro;

--- a/drivers/enttec-open-usb-dmx.js
+++ b/drivers/enttec-open-usb-dmx.js
@@ -1,4 +1,6 @@
 const SerialPort = require('serialport');
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
 
 function EnttecOpenUsbDMX(deviceId, options) {
   const self = this;
@@ -59,6 +61,8 @@ EnttecOpenUsbDMX.prototype.update = function (u) {
   for (const c in u) {
     this.universe[c] = u[c];
   }
+
+  this.emit('update', u);
 };
 
 EnttecOpenUsbDMX.prototype.updateAll = function (v) {
@@ -70,5 +74,7 @@ EnttecOpenUsbDMX.prototype.updateAll = function (v) {
 EnttecOpenUsbDMX.prototype.get = function (c) {
   return this.universe[c];
 };
+
+util.inherits(EnttecOpenUsbDMX, EventEmitter);
 
 module.exports = EnttecOpenUsbDMX;

--- a/drivers/enttec-usb-dmx-pro.js
+++ b/drivers/enttec-usb-dmx-pro.js
@@ -1,4 +1,6 @@
 const SerialPort = require('serialport');
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
 
 const ENTTEC_PRO_DMX_STARTCODE = 0x00;
 const ENTTEC_PRO_START_OF_MSG = 0x7e;
@@ -56,6 +58,8 @@ EnttecUSBDMXPRO.prototype.update = function (u) {
     this.universe[c] = u[c];
   }
   this.sendUniverse();
+
+  this.emit('update', u);
 };
 
 EnttecUSBDMXPRO.prototype.updateAll = function (v) {
@@ -68,5 +72,7 @@ EnttecUSBDMXPRO.prototype.updateAll = function (v) {
 EnttecUSBDMXPRO.prototype.get = function (c) {
   return this.universe[c];
 };
+
+util.inherits(EnttecUSBDMXPRO, EventEmitter);
 
 module.exports = EnttecUSBDMXPRO;

--- a/drivers/null.js
+++ b/drivers/null.js
@@ -1,4 +1,7 @@
-function Null(deviceId, options) {
+const util = require('util');
+const EventEmitter = require('events').EventEmitter;
+
+function NullDriver(deviceId, options) {
   const self = this;
 
   options = options || {};
@@ -6,7 +9,7 @@ function Null(deviceId, options) {
   self.start();
 }
 
-Null.prototype.start = function () {
+NullDriver.prototype.start = function () {
   const self = this;
 
   self.timeout = setInterval(() => {
@@ -14,29 +17,33 @@ Null.prototype.start = function () {
   }, 1000);
 };
 
-Null.prototype.stop = function () {
+NullDriver.prototype.stop = function () {
   clearInterval(this.timeout);
 };
 
-Null.prototype.close = cb => {
-  cb(null);
+NullDriver.prototype.close = cb => {
+  cb(nullDriver);
 };
 
-Null.prototype.update = function (u) {
+NullDriver.prototype.update = function (u) {
   for (const c in u) {
     this.universe[c] = u[c];
   }
   console.log(this.universe.slice(1));
+
+  this.emit('update', u);
 };
 
-Null.prototype.updateAll = function (v) {
+NullDriver.prototype.updateAll = function (v) {
   for (let i = 1; i <= 512; i++) {
     this.universe[i] = v;
   }
 };
 
-Null.prototype.get = function (c) {
+NullDriver.prototype.get = function (c) {
   return this.universe[c];
 };
 
-module.exports = Null;
+util.inherits(NullDriver, EventEmitter);
+
+module.exports = NullDriver;

--- a/index.js
+++ b/index.js
@@ -26,12 +26,16 @@ class DMX {
 
   addUniverse(name, driver, deviceId, options) {
     this.universes[name] = new this.drivers[driver](deviceId, options);
+
+    this.universes[name].on("update", (channels) => {
+      this.emit('update', name, channels);
+    })
+
     return this.universes[name];
   }
 
   update(universe, channels) {
     this.universes[universe].update(channels);
-    this.emit('update', universe, channels);
   }
 
   updateAll(universe, value) {


### PR DESCRIPTION
Currently the update event is only sent when individual calls are made the library. this means animations do not trigger events. I have passed the event handling down a layer into the driver to cover this.

I was not able to change the event handling in the main library class as animations are run against the driver's universe object and I didn't want to break existing functionality with animations.