### PR TITLE
Added filter function to animation class

### DIFF
--- a/anim.js
+++ b/anim.js
@@ -1,7 +1,7 @@
 const ease = require('./easing.js').ease;
 
 class Anim {
-  constructor({ loop } = {}) {
+  constructor({ loop, filter } = {}) {
     this.frameDelay = 1;
     this.animations = [];
     this.lastAnimation = 0;
@@ -10,6 +10,7 @@ class Anim {
     this.startTime = null;
     this.loops = loop || 1;
     this.currentLoop = 0;
+    this.filter = filter;
   }
 
   add(to, duration = 0, options = {}) {
@@ -77,6 +78,10 @@ class Anim {
           ...completedAnimations.map(a => a.to)
         );
 
+        if (typeof this.filter === 'function') {
+          this.filter(completedAnimationStatesToSet);
+        }
+
         universe.update(completedAnimationStatesToSet);
       }
 
@@ -130,6 +135,11 @@ class Anim {
               startValue + easeProgress * (endValue - startValue)
             );
           }
+
+          if (typeof this.filter === 'function') {
+            this.filter(intermediateValues);
+          }
+
           universe.update(intermediateValues);
         }
       }

--- a/readme.md
+++ b/readme.md
@@ -67,9 +67,17 @@ The following Devices are known:
 
 ### Class DMX.Animation
 
-#### new DMX.Animation()
+#### new DMX.Animation([options])
 
 Create a new DMX Animation instance. This can be chained similar to jQuery.
+
+The options Object takes the following keys:
+
+- <code>loops</code> - Number, the number of times this animation sequence will loop when <code>run</code> is invoked. This value is overridden if you invoke <code>runLoop</code>.
+- <code>filter</code> - Function, allows you to read or modify the values being set to each channel during each animation step.
+
+If you specify a <code>filter</code> function, it must take a single object parameter in which keys are channel numbers and values are the values to set those channels to.
+You may modify the values in the object to override the values in real-time, for example to scale channel brightness based on a master fader.
 
 #### animation.add(to, duration, options)
 


### PR DESCRIPTION
Per discussion in IRC earlier today with @wiedi, this PR adds a `filter` property to the options object passed to the `DMX.Animation()` constructor, allowing for consumer applications to view and modify channel values set by animations in real-time. This is useful particularly in cases where you want to scale the value of all channels based on some multiplier, e.g. a master brightness fader or a blackout button.