### PR TITLE
update serialport package to version 9.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "dependencies": {
     "sacn": "^3.2.1",
-    "serialport": "^8.0.5",
+    "serialport": "^9.0.8",
     "socket.io": "^2.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I updated serialport to 9.x to make this package work with lts version of node (14.x). 
The used api calls of serialport seem to be work fine as well with the new version.

I tested the driver `enttec-usb-dmx-pro` successfully with an enttec pro device.