### PR TITLE
fixes #154 use Serialport 10 syntax

### DIFF
--- a/drivers/enttec-usb-dmx-pro.js
+++ b/drivers/enttec-usb-dmx-pro.js
@@ -1,4 +1,4 @@
-const SerialPort = require('serialport');
+const { SerialPort } = require('serialport');
 const util = require('util');
 const EventEmitter = require('events').EventEmitter;
 
@@ -13,7 +13,8 @@ function EnttecUSBDMXPRO(deviceId, options = {}) {
   this.readyToWrite = true;
   this.interval = 1000 / (options.dmx_speed || 40);
 
-  this.dev = new SerialPort(deviceId, {
+  this.dev = new SerialPort({
+    'path': deviceId,
     'baudRate': 250000,
     'dataBits': 8,
     'stopBits': 2,


### PR DESCRIPTION
Two changes that follow the Serialport 10 upgrade guide:
https://serialport.io/docs/guide-upgrade#upgrading-from-9x-to-10x