### PR TITLE
Null driver: close() does stop().

### DIFF
--- a/drivers/null.js
+++ b/drivers/null.js
@@ -18,6 +18,7 @@ NullDriver.prototype.stop = function () {
 };
 
 NullDriver.prototype.close = cb => {
+  this.stop();
   cb(null);
 };
 


### PR DESCRIPTION
Null driver: close( ) calls stop() to cancel the periodic data logging.