### PR TITLE
fix: changed loop variable from const to let

### DIFF
--- a/drivers/bbdmx.js
+++ b/drivers/bbdmx.js
@@ -22,7 +22,7 @@ BBDMX.prototype.sendUniverse = function () {
     let channel;
     let messageBuffer = Buffer.from(UNIVERSE_LEN.toString());
 
-    for (const i = 1; i <= UNIVERSE_LEN; i++) {
+    for (let i = 1; i <= UNIVERSE_LEN; i++) {
       channel = Buffer.from(' ' + this.universe[i]);
       messageBuffer = Buffer.concat([messageBuffer, channel]);
     }
@@ -55,7 +55,7 @@ BBDMX.prototype.update = function (u, extraData) {
 };
 
 BBDMX.prototype.updateAll = function (v) {
-  for (const i = 1; i <= UNIVERSE_LEN; i++) {
+  for (let i = 1; i <= UNIVERSE_LEN; i++) {
     this.universe[i] = v;
   }
 };


### PR DESCRIPTION
When trying to use the library, there's an error saying the following:

```
25 |     for (const i = 1; i <= UNIVERSE_LEN; i++) {
                                              ^
error: This assignment will throw because "i" is a constant
    at {BASE_PATH}\node_modules\dmx\drivers\bbdmx.js:25:42
```

This PR changes the `i` type from `const` to `let` to allow the for loop to re-assign the variable.
  